### PR TITLE
Nginx-cannot-forward-headers

### DIFF
--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -10,7 +10,7 @@ upstream backend {
 server {
   listen 80;
   listen [::]:80;
-
+  underscores_in_headers on;
   location / {
     proxy_pass http://frontend;
     proxy_redirect off;
@@ -22,6 +22,11 @@ server {
 
   location /api {
     proxy_pass http://backend;
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Host $server_name;
+
     proxy_buffering on;
   }
 


### PR DESCRIPTION
Đã fix lỗi backend api không nhận được headers khi tạo user admin